### PR TITLE
Change to use IServiceLocator to allow faking the ServiceProvider and add an example test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+codealike.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": {              
+              "kind":"build",
+              "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/CleanArchitecture.Core/CleanArchitecture.Core.csproj
+++ b/src/CleanArchitecture.Core/CleanArchitecture.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CleanArchitecture.Core/Services/EntryPointService.cs
+++ b/src/CleanArchitecture.Core/Services/EntryPointService.cs
@@ -40,7 +40,7 @@ namespace CleanArchitecture.Core.Services
                 using var scope = _serviceScopeFactoryLocator.CreateScope();
                     var repository =
                         scope.ServiceProvider
-                            .GetRequiredService<IRepository>();
+                            .GetService<IRepository>();
 
                 // read from the queue
                 string message = await _queueReceiver.GetMessageFromQueue(_settings.ReceivingQueueName);

--- a/src/CleanArchitecture.Core/Services/IServiceLocator.cs
+++ b/src/CleanArchitecture.Core/Services/IServiceLocator.cs
@@ -6,7 +6,6 @@ namespace CleanArchitecture.Core.Services
     public interface IServiceLocator : IDisposable
     {
         IServiceScope CreateScope();
-        void Dispose();
         T Get<T>();
     }
 }

--- a/src/CleanArchitecture.Core/Services/IServiceLocator.cs
+++ b/src/CleanArchitecture.Core/Services/IServiceLocator.cs
@@ -1,0 +1,12 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CleanArchitecture.Core.Services
+{
+    public interface IServiceLocator : IDisposable
+    {
+        IServiceScope CreateScope();
+        void Dispose();
+        T Get<T>();
+    }
+}

--- a/src/CleanArchitecture.Core/Services/ServiceScopeFactoryLocator.cs
+++ b/src/CleanArchitecture.Core/Services/ServiceScopeFactoryLocator.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CleanArchitecture.Core.Services
+{
+    /// <summary>
+    /// A wrapper around ServiceScopeFactory to make it easier to fake out with MOQ.
+    /// </summary>
+    /// <see cref="https://stackoverflow.com/a/53509491/54288"/>
+    public sealed class ServiceScopeFactoryLocator : IServiceLocator
+    {
+        private readonly IServiceScopeFactory _factory;
+        private IServiceScope _scope;
+
+        public ServiceScopeFactoryLocator(IServiceScopeFactory factory)
+        {
+            _factory = factory;
+        }
+
+        public T Get<T>()
+        {
+            CreateScope();
+
+            return _scope.ServiceProvider.GetService<T>();
+        }
+
+        public IServiceScope CreateScope()
+        {
+            if (_scope == null)
+                _scope = _factory.CreateScope();
+            return _scope;
+        }
+
+        public void Dispose()
+        {
+            _scope?.Dispose();
+            _scope = null;
+        }
+    }
+}

--- a/src/CleanArchitecture.Worker/Program.cs
+++ b/src/CleanArchitecture.Worker/Program.cs
@@ -31,6 +31,7 @@ namespace CleanArchitecture.Worker
                 {
                     services.AddSingleton(typeof(ILoggerAdapter<>), typeof(LoggerAdapter<>));
                     services.AddSingleton<IEntryPointService, EntryPointService>();
+                    services.AddSingleton<IServiceLocator, ServiceScopeFactoryLocator>();
 
                     // Infrastructure.ContainerSetup
                     services.AddMessageQueues();

--- a/tests/CleanArchitecture.UnitTests/Core/EntryPointServiceExecuteAsync.cs
+++ b/tests/CleanArchitecture.UnitTests/Core/EntryPointServiceExecuteAsync.cs
@@ -9,15 +9,33 @@ namespace CleanArchitecture.UnitTests
 {
     public class EntryPointServiceExecuteAsync
     {
-        [Fact]
-        public async Task LogsExceptionsEncountered()
+        private static (EntryPointService, Mock<ILoggerAdapter<EntryPointService>>) Factory()
         {
             var logger = new Mock<ILoggerAdapter<EntryPointService>>();
             var service = new EntryPointService(logger.Object, null, null, null, null, null);
+            return (service, logger);
+        }
+
+        [Fact]
+        public async Task LogsExceptionsEncountered()
+        {
+            var (service, logger) = Factory();
 
             await service.ExecuteAsync();
 
             logger.Verify(l => l.LogError(It.IsAny<NullReferenceException>(), It.IsAny<string>()), Times.Once);
+        }
+    
+        [Fact]
+        public async Task RunCodeInsideOfCreateScope()
+        {
+            // example of getting inside of the CreateScope
+            // you'll want to remove this test later
+            var (service, logger) = Factory();
+
+            await service.ExecuteAsync();
+
+            // didn't blow up, the scope was created
         }
     }
 }

--- a/tests/CleanArchitecture.UnitTests/Core/EntryPointServiceExecuteAsync.cs
+++ b/tests/CleanArchitecture.UnitTests/Core/EntryPointServiceExecuteAsync.cs
@@ -1,5 +1,7 @@
 using CleanArchitecture.Core.Interfaces;
 using CleanArchitecture.Core.Services;
+using CleanArchitecture.Core.Settings;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using System;
 using System.Threading.Tasks;
@@ -9,17 +11,42 @@ namespace CleanArchitecture.UnitTests
 {
     public class EntryPointServiceExecuteAsync
     {
-        private static (EntryPointService, Mock<ILoggerAdapter<EntryPointService>>) Factory()
+        private static (EntryPointService, Mock<ILoggerAdapter<EntryPointService>>, Mock<IQueueReceiver>, Mock<IServiceLocator>) Factory()
         {
             var logger = new Mock<ILoggerAdapter<EntryPointService>>();
-            var service = new EntryPointService(logger.Object, null, null, null, null, null);
-            return (service, logger);
+            var settings = new EntryPointSettings
+            {
+                ReceivingQueueName = "testQueue"
+            };
+            var queueReceiver = new Mock<IQueueReceiver>();
+            var serviceLocator = new Mock<IServiceLocator>();
+
+            var serviceProvider = SetupCreateScope(serviceLocator);
+
+            // GetRequiredService is an extension method, I don't know how to continue
+            serviceProvider.Setup(sp => sp.GetRequiredService(typeof(IRepository)))
+                .Returns(new Mock<IRepository>());
+
+            var service = new EntryPointService(logger.Object, settings, queueReceiver.Object, null, serviceLocator.Object, null);
+            return (service, logger, queueReceiver, serviceLocator);
+        }
+
+        private static Mock<IServiceProvider> SetupCreateScope(Mock<IServiceLocator> serviceLocator)
+        {
+            Mock<IServiceScope> scope = new Mock<IServiceScope>();
+            serviceLocator.Setup(sl => sl.CreateScope())
+                            .Returns(scope.Object);
+            Mock<IServiceProvider> serviceProvider = new Mock<IServiceProvider>();
+            scope.Setup(s => s.ServiceProvider)
+                .Returns(serviceProvider.Object);
+
+            return serviceProvider;
         }
 
         [Fact]
         public async Task LogsExceptionsEncountered()
         {
-            var (service, logger) = Factory();
+            var (service, logger, _, _) = Factory();
 
             await service.ExecuteAsync();
 
@@ -27,15 +54,14 @@ namespace CleanArchitecture.UnitTests
         }
     
         [Fact]
-        public async Task RunCodeInsideOfCreateScope()
+        public async Task MessageWasRetrievedFromTheQueue()
         {
             // example of getting inside of the CreateScope
-            // you'll want to remove this test later
-            var (service, logger) = Factory();
+            var (service, _, queueReceiver, _) = Factory();
 
             await service.ExecuteAsync();
 
-            // didn't blow up, the scope was created
+            queueReceiver.Verify(qr => qr.GetMessageFromQueue("testQueue"), Times.Once);
         }
     }
 }


### PR DESCRIPTION
This is for issue #3.

I upgraded the .netStandard version 2.1. I can pull that out if you'd like.