### PR TITLE
Update dotnet image version in Dockerfile

### DIFF
--- a/src/CleanArchitecture.Worker/Dockerfile
+++ b/src/CleanArchitecture.Worker/Dockerfile
@@ -1,7 +1,7 @@
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["src/CleanArchitecture.Worker/CleanArchitecture.Worker.csproj", "src/CleanArchitecture.Worker/"]
 RUN dotnet restore "src/CleanArchitecture.Worker/CleanArchitecture.Worker.csproj"


### PR DESCRIPTION
The project targets `net7.0`, but the Dockerfile has not been updated yet. The `build` step now also uses the `sdk` image because the runtime image cannot build the application.