### PR TITLE
Add workflow to publish to NuGet and updated version to be 1.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: publish Ardalis.CleanArchitecture.WorkerService Template to nuget
+on:
+  push:
+    branches:
+      - main # Your default release branch
+    paths:
+      - 'CleanArchitecture.WorkerService.nuspec'
+jobs:
+  publish:
+    name: list on nuget
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: '5.x'
+          
+      - name: Package the template
+        run: nuget pack CleanArchitecture.WorkerService.nuspec -NoDefaultExcludes
+        
+      - name: Publish to nuget.org
+        run: nuget push Ardalis.CleanArchitecture.WorkerService.Template.*.nupkg -src https://api.nuget.org/v3/index.json ${{secrets.NUGET_API_KEY}}

--- a/CleanArchitecture.WorkerService.nuspec
+++ b/CleanArchitecture.WorkerService.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Ardalis.CleanArchitecture.WorkerService.Template</id>
     <title>ASP.NET Core Clean Architecture Solution for Worker Service</title>
-    <version>9.1.2</version>
+    <version>1.0.0</version>
     <authors>Steve Smith</authors>
     <description>
       The Clean Architecture Solution Template for Worker service popularized by Steve @ardalis Smith.


### PR DESCRIPTION
@ardalis - Following up with [this](https://github.com/ardalis/CleanArchitecture.WorkerService/pull/205) PR I've revised the version to be 1.0.0 since this is the first time the template is getting released on NuGet. Please feel free to suggest/edit if you have any other version number in your mind

Reference [issue](https://github.com/ardalis/CleanArchitecture.WorkerService/issues/120)